### PR TITLE
Fix submission entity + update methods

### DIFF
--- a/backend/src/question/question.service.ts
+++ b/backend/src/question/question.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { CreateQuestionDto } from './dto/create-question.dto';
 import { UpdateQuestionDto } from './dto/update-question.dto';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DataSource, DeleteResult, Repository } from 'typeorm';
+import { DataSource, DeleteResult, Repository, UpdateResult } from 'typeorm';
 import { Question } from './entities/question.entity';
 
 @Injectable()
@@ -20,7 +20,7 @@ export class QuestionService {
     return await this.questionRepository.find();
   }
 
-  async findOne(id: number): Promise<Question> {
+  async findByKey(id: number): Promise<Question> {
     return await this.questionRepository.findOne({
       where: {
         id: id
@@ -28,8 +28,8 @@ export class QuestionService {
     })
   }
 
-  async update(id: number, updateQuestionDto: UpdateQuestionDto): Promise<Question> {
-    return await this.questionRepository.save(updateQuestionDto);
+  async update(id: number, updateQuestionDto: UpdateQuestionDto): Promise<UpdateResult> {
+    return await this.questionRepository.update(id, updateQuestionDto);
   }
 
   async remove(id: number): Promise<DeleteResult> {

--- a/backend/src/student/student.service.ts
+++ b/backend/src/student/student.service.ts
@@ -3,7 +3,7 @@ import { CreateStudentDto } from './dto/create-student.dto';
 import { UpdateStudentDto } from './dto/update-student.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Student } from './entities/student.entity';
-import { DeleteResult, Repository } from 'typeorm';
+import { DeleteResult, Repository, UpdateResult } from 'typeorm';
 
 @Injectable()
 export class StudentService {
@@ -19,7 +19,7 @@ export class StudentService {
     return await this.studentRepository.find();
   }
 
-  async findOne(id: number): Promise<Student> {
+  async findByKey(id: number): Promise<Student> {
     return await this.studentRepository.findOne({
       where: {
         id: id
@@ -27,8 +27,8 @@ export class StudentService {
     });
   }
 
-  async update(id: number, updateStudentDto: UpdateStudentDto): Promise<Student> {
-    return await this.studentRepository.save(updateStudentDto);
+  async update(id: number, updateStudentDto: UpdateStudentDto): Promise<UpdateResult> {
+    return await this.studentRepository.update(id, updateStudentDto);
   }
 
   async remove(id: number): Promise<DeleteResult> {

--- a/backend/src/submission/dto/submission-key.dto.ts
+++ b/backend/src/submission/dto/submission-key.dto.ts
@@ -1,0 +1,4 @@
+import { OmitType, PickType } from "@nestjs/mapped-types";
+import { SubmissionDto } from "./submission.dto";
+
+export class SubmissionKeyDto extends PickType(SubmissionDto, ['student_id', 'question_id', 'submission_time']) {}

--- a/backend/src/submission/entities/submission.entity.ts
+++ b/backend/src/submission/entities/submission.entity.ts
@@ -1,7 +1,8 @@
 import { Question } from "src/question/entities/question.entity";
 import { Student } from "src/student/entities/student.entity";
-import { Column, CreateDateColumn, ManyToOne, PrimaryColumn } from "typeorm";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
 
+@Entity("admin.submission")
 export class Submission {
     @PrimaryColumn({ type: "int8" })
     student_id: number;
@@ -9,7 +10,7 @@ export class Submission {
     @PrimaryColumn({ type: "int8" })
     question_id: number;
 
-    @CreateDateColumn({ type: "timestamp", default: () => "CURRENT_TIMESTAMP(6)" })
+    @PrimaryColumn({ type: "timestamptz", default: () => "CURRENT_TIMESTAMP(6)" })
     submission_time: Date;
 
     @Column("bool", { nullable: false, default: false })
@@ -28,8 +29,10 @@ export class Submission {
     status: string;
 
     @ManyToOne(() => Student, (student) => student.id, { nullable: false, eager: false, cascade: false })
+    @JoinColumn({ name: "student_id", referencedColumnName: "id" })
     student: Student;
 
     @ManyToOne(() => Question, (question) => question.id, { nullable: false, eager: false, cascade: false })
+    @JoinColumn({ name: "question_id", referencedColumnName: "id" })
     question: Question;
 }

--- a/backend/src/submission/entities/submission.entity.ts
+++ b/backend/src/submission/entities/submission.entity.ts
@@ -10,7 +10,7 @@ export class Submission {
     @PrimaryColumn({ type: "int8" })
     question_id: number;
 
-    @PrimaryColumn({ type: "timestamptz", default: () => "CURRENT_TIMESTAMP(6)" })
+    @PrimaryColumn({ type: "timestamptz", precision: 3, default: () => "CURRENT_TIMESTAMP(3)" })
     submission_time: Date;
 
     @Column("bool", { nullable: false, default: false })

--- a/backend/src/submission/submission.service.ts
+++ b/backend/src/submission/submission.service.ts
@@ -3,7 +3,8 @@ import { CreateSubmissionDto } from './dto/create-submission.dto';
 import { UpdateSubmissionDto } from './dto/update-submission.dto';
 import { Submission } from './entities/submission.entity';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository } from 'typeorm';
+import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import { SubmissionKeyDto } from './dto/submission-key.dto';
 
 @Injectable()
 export class SubmissionService {
@@ -19,17 +20,18 @@ export class SubmissionService {
     return await this.submissionRepository.find();
   }
 
-  async findOne(student_id: number, question_id: number): Promise<Submission> {
+  async findByKey(student_id: number, question_id: number, submission_time: Date): Promise<Submission> {
     return await this.submissionRepository.findOne({
       where: {
         student_id: student_id,
-        question_id: question_id
+        question_id: question_id,
+        submission_time: submission_time
       }
     });
   }
 
-  async update(id: number, updateSubmissionDto: UpdateSubmissionDto): Promise<Submission> {
-    return await this.submissionRepository.save(updateSubmissionDto);
+  async update(key: SubmissionKeyDto, updateSubmissionDto: UpdateSubmissionDto): Promise<UpdateResult> {
+    return await this.submissionRepository.update(key, updateSubmissionDto);
   }
 
   async remove(id: number): Promise<DeleteResult> {


### PR DESCRIPTION
Submission entity did not include `submission_time` as part of the composite primary key.

The foreign key constraints are also not working properly due to wrong configuration.

The submission entity was also not added as a entity under the "admin" datasource.

Update methods are using the `save` method and not the `update` method of TypeORM Repository.

There is an issue with updating Submission records because Javascript's `Date` type only supports up to precision 3 or milliseconds whereas the PostgreSQL default precision for timestamptz is precision 6 or microseconds. This mismatch causes the extra precision to be dropped when Submission records are queried, which will lead to issues updating the Submission record.

This PR addresses all issues.