### PR TITLE
Add auto student registration + get correct submissions API

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -18,10 +18,18 @@ paths:
             schema:
               type: object
               properties:
-                question_id:
+                name:
                   type: string
-                  description: id of question to be set up
-                  example: 1
+                  description: schema name to be initialized for the question
+                  example: public
+                question_schema:
+                  type: string
+                  description: schema initialization script for the question
+                  example: CREATE TABLE test (id INT PRIMARY KEY, name VARCHAR(255));
+                question_data:
+                  type: string
+                  description: data population script for the question
+                  example: INSERT INTO test VALUES (1, 'Alice');
       responses:
         '201':
           description: schema initialized and data populated for the question
@@ -60,6 +68,57 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Submission'
+  /admin/correct-submission:
+    post:
+      summary: Gets all correct submissions
+      description: Returns all correct submissions sorted in descending order of submission time
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                student_id:
+                  type: string
+                  description: id of the student
+                  example: 1
+                question_id:
+                  type: string
+                  description: id of the question
+                  example: 1
+                submission_time:
+                  type: string
+                  description: time of submission
+                  example: 2024-03-27T15:31:57.094Z
+                is_correct:
+                  type: boolean
+                  description: whether the submission is correct
+                  example: true
+                planning_time:
+                  type: string
+                  description: time taken to plan the submission
+                  example: 0.231
+                execution_time:
+                  type: string
+                  description: time taken to execute the submission
+                  example: 0.061
+                query:
+                  type: string
+                  description: query submitted
+                  example: SELECT * FROM test;
+                status:
+                  type: string
+                  enum: [COMPLETED, PENDING, TIMEOUT, FAILED]
+                  description: status of the submission
+                  example: COMPLETED
+      responses:
+        '201':
+          description: submission corrected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
   /admin/submissions:
     get:
       summary: Get all submissions
@@ -104,6 +163,14 @@ paths:
                   type: string
                   description: id of the student
                   example: 1
+                student_name:
+                  type: string
+                  description: name of the student
+                  example: Alice
+                student_email:
+                  type: string
+                  description: email of the student
+                  example: alice@gmail.com
                 question_id:
                   type: string
                   description: id of the question
@@ -114,11 +181,12 @@ paths:
                   example: SELECT * FROM test;
       responses:
         '201':
-          description: submission created and query queued for evaluation
+          description: submission created and query queued for evaluation. planning_time, execution_time and is_correct will be updated later
+            and will be 0.00, 0.00 and false respectively while status is PENDING
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SubmitDto'
+                $ref: '#/components/schemas/Submission'
 
 components:
   schemas:
@@ -158,29 +226,5 @@ components:
           enum: [COMPLETED, PENDING, TIMEOUT, FAILED]
           description: status of the submission
           example: COMPLETED
-    SubmitDto:
-      type: object
-      properties:
-        student_id:
-          type: string
-          description: id of the student
-          example: 1
-        question_id:
-          type: string
-          description: id of the question
-          example: 1
-        submission_time:
-          type: string
-          description: time of submission
-          example: 2024-03-27T15:31:57.094Z
-        query:
-          type: string
-          description: query submitted
-          example: SELECT * FROM test;
-        status:
-          type: string
-          enum: [COMPLETED, PENDING, TIMEOUT, FAILED]
-          description: status of the submission
-          example: PENDING
 
       

--- a/backend/src/admin.controller.ts
+++ b/backend/src/admin.controller.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Post, Body, Query } from '@nestjs/common';
 import { AdminService } from './admin.service';
-import { SUBMISSION_STATUS } from './submission/constants/submission.constant';
-import { SubmitDto } from './admin.dto';
+import { SubmitDto, SubmitResponseDto } from './admin.dto';
 import { SubmissionDto } from './submission/dto/submission.dto';
+import { SUBMISSION_STATUS } from './submission/constants/submission.constant';
 
 @Controller("admin")
 export class AdminController {
@@ -10,7 +10,7 @@ export class AdminController {
 
   @Get("submission")
   async getSubmission(
-    @Query("student_id") student_id: number,
+    @Query("student_id") student_id: string,
     @Query("question_id") question_id: number,
     @Query("submission_time") submission_time: Date
   ): Promise<SubmissionDto> {
@@ -23,35 +23,37 @@ export class AdminController {
 
   @Get("submissions")
   async getAllSubmissions(
-    @Query("student_id") student_id: number,
+    @Query("student_id") student_id: string,
     @Query("question_id") question_id: number
   ): Promise<SubmissionDto[]> {
     return await this.adminService.getAllSubmissions(student_id, question_id);
   }
 
+  @Get("correct-submissions")
+  async getAllCorrectSubmissions(
+    @Query("student_id") student_id: string,
+    @Query("question_id") question_id: number
+  ): Promise<SubmissionDto[]> {
+    return await this.adminService.getAllCorrectSubmissions(student_id, question_id);
+  }
+
   @Post("submit")
   async submit(
-    @Body("student_id") student_id: number,
-    @Body("question_id") question_id: number,
-    @Body("query") query: string
-  ): Promise<SubmitDto> {
-    const submission = await this.adminService.queueSubmissionEvaluation({
-      student_id: student_id,
-      question_id: question_id,
+    @Body() submitDto: SubmitDto
+  ): Promise<SubmissionDto> {
+    return await this.adminService.queueSubmissionEvaluation({
+      id: submitDto.student_id,
+      name: submitDto.student_name,
+      email: submitDto.student_email
+    }, {
+      student_id: submitDto.student_id,
+      question_id: submitDto.question_id,
       is_correct: false,
       planning_time: 0.00,
       execution_time: 0.00,
-      query: query,
+      query: submitDto.query,
       status: SUBMISSION_STATUS.PENDING
     });
-
-    return {
-      student_id: submission.student_id,
-      question_id: submission.question_id,
-      submission_time: submission.submission_time,
-      query: submission.query,
-      status: submission.status
-    }
   }
 
   @Post('setup')

--- a/backend/src/admin.dto.ts
+++ b/backend/src/admin.dto.ts
@@ -1,7 +1,17 @@
-export class SubmitDto {
-    readonly student_id: number;
+import { StudentDto } from "./student/dto/student.dto";
+
+export class SubmitResponseDto {
+    readonly student_id: string;
     readonly question_id: number;
     readonly submission_time: Date;
     readonly query: string;
     readonly status: string;
+}
+
+export class SubmitDto {
+    readonly student_id: string;
+    readonly student_name: string;
+    readonly student_email: string;
+    readonly question_id: number;
+    readonly query: string;
 }

--- a/backend/src/question/question.controller.ts
+++ b/backend/src/question/question.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import { Controller, Post, Body, Get, Query, Param } from '@nestjs/common';
 import { QuestionService } from './question.service';
 import { CreateQuestionDto } from './dto/create-question.dto';
 
@@ -19,7 +19,7 @@ export class QuestionController {
   }
 
   @Get(':id')
-  async getQuestion(@Query('id') id: number) {
+  async getQuestion(@Param('id') id: number) {
     return await this.questionService.findByKey(id);
   }
 

--- a/backend/src/student/dto/create-student.dto.ts
+++ b/backend/src/student/dto/create-student.dto.ts
@@ -1,4 +1,0 @@
-import { OmitType } from "@nestjs/mapped-types";
-import { StudentDto } from "./student.dto";
-
-export class CreateStudentDto extends OmitType(StudentDto, ['id']) {}

--- a/backend/src/student/dto/student.dto.ts
+++ b/backend/src/student/dto/student.dto.ts
@@ -1,5 +1,5 @@
 export class StudentDto {
-    readonly id: number;
+    readonly id: string;
     readonly name: string;
     readonly email: string;
 }

--- a/backend/src/student/entities/student.entity.ts
+++ b/backend/src/student/entities/student.entity.ts
@@ -1,9 +1,9 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { Column, Entity, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 
 @Entity({ schema: "admin", name: "student" })
 export class Student {
-    @PrimaryGeneratedColumn({ type: "int8" })
-    id: number;
+    @PrimaryColumn({ type: "text" })
+    id: string;
 
     @Column("text", { nullable: false })
     name: string;

--- a/backend/src/student/student.service.ts
+++ b/backend/src/student/student.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { CreateStudentDto } from './dto/create-student.dto';
 import { UpdateStudentDto } from './dto/update-student.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Student } from './entities/student.entity';
 import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import { StudentDto } from './dto/student.dto';
 
 @Injectable()
 export class StudentService {
@@ -11,15 +11,15 @@ export class StudentService {
     @InjectRepository(Student, "admin") private readonly studentRepository: Repository<Student>
   ) {}
 
-  async create(createStudentDto: CreateStudentDto): Promise<Student> {
-    return await this.studentRepository.save(createStudentDto);
+  async create(studentDto: StudentDto): Promise<Student> {
+    return await this.studentRepository.save(studentDto);
   }
 
   async findAll(): Promise<Student[]>{
     return await this.studentRepository.find();
   }
 
-  async findByKey(id: number): Promise<Student> {
+  async findByKey(id: string): Promise<Student> {
     return await this.studentRepository.findOne({
       where: {
         id: id

--- a/backend/src/submission/dto/submission.dto.ts
+++ b/backend/src/submission/dto/submission.dto.ts
@@ -1,5 +1,5 @@
 export class SubmissionDto {
-    readonly student_id: number;
+    readonly student_id: string;
     readonly question_id: number;
     readonly submission_time: Date;
     readonly is_correct: boolean;

--- a/backend/src/submission/entities/submission.entity.ts
+++ b/backend/src/submission/entities/submission.entity.ts
@@ -5,8 +5,8 @@ import { SubmissionKeyDto } from "../dto/submission-key.dto";
 
 @Entity({ schema: "admin", name: "submission" })
 export class Submission {
-    @PrimaryColumn({ type: "int8" })
-    student_id: number;
+    @PrimaryColumn({ type: "text" })
+    student_id: string;
 
     @PrimaryColumn({ type: "int8" })
     question_id: number;

--- a/backend/src/submission/submission.service.ts
+++ b/backend/src/submission/submission.service.ts
@@ -20,7 +20,22 @@ export class SubmissionService {
     return await this.submissionRepository.find();
   }
 
-  async findByStudentIdAndQuestionIdOrderBySubmissionTimeDesc(student_id: number, question_id: number): Promise<Submission[]> {
+  async findByStudentIdAndQuestionIdAndIsCorrectOrderBySubmissionTimeDesc(
+    student_id: string, question_id: number, is_correct: boolean
+  ): Promise<Submission[]> {
+    return await this.submissionRepository.find({
+      where: {
+        student_id: student_id,
+        question_id: question_id,
+        is_correct: is_correct
+      },
+      order: {
+        submission_time: "DESC"
+      }
+    });
+  }
+
+  async findByStudentIdAndQuestionIdOrderBySubmissionTimeDesc(student_id: string, question_id: number): Promise<Submission[]> {
     return await this.submissionRepository.find({
       where: {
         student_id: student_id,


### PR DESCRIPTION
See API updates in openapi.yaml.

DB updated to change `id` PK of `student` table from auto-incrementing `bigint` to `text`. `submission` table's `student_id` field and associated foreign key constraint also updated.

In particular:
- submit API request and response data are changed
- submit API now auto registers student id
- new API to get correct submissions added
- setup API updated to fit Tay's implementation